### PR TITLE
feat(preset)!: add CSS-first typography preset

### DIFF
--- a/e2e/index.test.ts
+++ b/e2e/index.test.ts
@@ -28,4 +28,14 @@ describe('tailwindcss-flow-type', () => {
 		expect(css).toContain('.text-base');
 		expect(css).toContain('font-size: clamp(1rem, calc(1rem + (1.25rem - 1rem)');
 	});
+
+	it('should generate semantic text utilities from the CSS-first preset', async () => {
+		const css = await generateCss('test-1.html', {
+			preset: true,
+		});
+
+		expect(css).toContain('--text-body: clamp(1rem, calc(1rem + (1.25rem - 1rem)');
+		expect(css).toContain('.text-body');
+		expect(css).toContain('font-size: var(--text-body)');
+	});
 });

--- a/e2e/utils/generate-css.ts
+++ b/e2e/utils/generate-css.ts
@@ -6,6 +6,7 @@ import postcss from 'postcss';
 interface GeneratePluginCssOptions {
 	onlyUtilities?: boolean;
 	options?: string;
+	preset?: boolean;
 	theme?: string;
 }
 
@@ -18,12 +19,14 @@ export default async function generateCss(
 	{ onlyUtilities = true, ...options }: GeneratePluginCssOptions = DEFAULT_OPTIONS
 ): Promise<string> {
 	const configInsert = options.theme ? `@theme {\n${options.theme}\n}` : '';
-	const pluginOptions = options.options ? ` ${options.options}` : ';';
+	const pluginDirective = options.preset ? '' : `@plugin '..'${options.options ? ` ${options.options}` : ';'}`;
+	const presetImport = options.preset ? `@import '../src/preset/default.css';` : '';
 
 	const result = await postcss(tailwindcss()).process(
 		`
-      @import ${onlyUtilities ? `'tailwindcss/utilities'` : `'tailwindcss'`} source(none);
-      @plugin '..'${pluginOptions}
+       @import ${onlyUtilities ? `'tailwindcss/utilities'` : `'tailwindcss'`} source(none);
+       ${presetImport}
+       ${pluginDirective}
       @source './${filename}';
 
       ${configInsert}`,

--- a/package.json
+++ b/package.json
@@ -39,6 +39,28 @@
 			},
 			"default": "./dist/index.js"
 		},
+		"./core": {
+			"import": {
+				"types": "./dist/core/index.d.ts",
+				"default": "./dist/core/index.js"
+			},
+			"require": {
+				"types": "./dist/core/index.d.cts",
+				"default": "./dist/core/index.cjs"
+			},
+			"default": "./dist/core/index.js"
+		},
+		"./plugin": {
+			"import": {
+				"types": "./dist/plugin/index.d.ts",
+				"default": "./dist/plugin/index.js"
+			},
+			"require": {
+				"types": "./dist/plugin/index.d.cts",
+				"default": "./dist/plugin/index.cjs"
+			},
+			"default": "./dist/plugin/index.js"
+		},
 		"./preset/default.css": "./dist/preset/default.css"
 	},
 	"scripts": {
@@ -49,8 +71,8 @@
 		"lint:ci": "eslint --cache --cache-strategy content .",
 		"lint:fix": "eslint --cache --fix .",
 		"prepare": "husky",
-		"prepublishOnly": "tsup",
-		"test": "tsup && bun test",
+		"prepublishOnly": "bun run build",
+		"test": "bun run build && bun test",
 		"typecheck": "tsc --noEmit"
 	},
 	"peerDependencies": {

--- a/package.json
+++ b/package.json
@@ -38,11 +38,13 @@
 				"default": "./dist/index.cjs"
 			},
 			"default": "./dist/index.js"
-		}
+		},
+		"./preset/default.css": "./dist/preset/default.css"
 	},
 	"scripts": {
-		"build": "tsup",
+		"build": "tsup && bun run copy:preset",
 		"commitlint": "commitlint --edit",
+		"copy:preset": "bun scripts/copy-preset.ts",
 		"lint": "eslint --cache .",
 		"lint:ci": "eslint --cache --cache-strategy content .",
 		"lint:fix": "eslint --cache --fix .",

--- a/scripts/copy-preset.ts
+++ b/scripts/copy-preset.ts
@@ -1,0 +1,6 @@
+import { mkdir } from 'node:fs/promises';
+
+const preset = Bun.file('src/preset/default.css');
+
+await mkdir('dist/preset', { recursive: true });
+await Bun.write('dist/preset/default.css', preset);

--- a/src/plugin/index.ts
+++ b/src/plugin/index.ts
@@ -1,0 +1,2 @@
+export * from '@/plugin';
+export { flowTypePlugin as default } from '@/plugin';

--- a/src/preset/default.css
+++ b/src/preset/default.css
@@ -1,0 +1,10 @@
+@theme {
+	--text-body: clamp(1rem, calc(1rem + (1.25rem - 1rem) * ((100vw - 20rem) / (96rem - 20rem))), 1.25rem);
+	--text-body--line-height: 1.6;
+
+	--text-heading: clamp(1.423828125rem, calc(1.423828125rem + (2.16rem - 1.423828125rem) * ((100vw - 20rem) / (96rem - 20rem))), 2.16rem);
+	--text-heading--line-height: 1.15;
+
+	--text-display: clamp(3rem, calc(3rem + (7rem - 3rem) * ((100vw - 20rem) / (96rem - 20rem))), 7rem);
+	--text-display--line-height: 0.9;
+}

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -4,7 +4,7 @@ export default defineConfig([
 	{
 		clean: true,
 		dts: true,
-		entry: ['./src/index.ts'],
+		entry: ['./src/index.ts', './src/core/index.ts', './src/plugin/index.ts'],
 		format: ['esm'],
 		minify: false,
 		sourcemap: false,
@@ -12,7 +12,7 @@ export default defineConfig([
 	{
 		clean: false,
 		dts: true,
-		entry: ['./src/index.ts'],
+		entry: ['./src/index.ts', './src/core/index.ts', './src/plugin/index.ts'],
 		format: ['cjs'],
 		minify: false,
 		sourcemap: false,
@@ -20,7 +20,7 @@ export default defineConfig([
 	{
 		clean: false,
 		dts: false,
-		entry: ['./src/index.ts'],
+		entry: ['./src/index.ts', './src/core/index.ts', './src/plugin/index.ts'],
 		format: ['esm', 'cjs'],
 		minify: true,
 		outExtension({ format }) {


### PR DESCRIPTION
## Summary

- add a static Tailwind v4 CSS-first typography preset
- publish it through `tailwindcss-flow-type/preset/default.css`
- copy the preset into the package distribution during builds
- verify preset consumption in the Tailwind E2E suite

## Verification

- `bun test`
- `bun run lint`
- `bun run typecheck`
- `bun run build`

Closes #119

Part of #115. Depends on #121.