### PR TITLE
feat(css)!: support theme token configuration

### DIFF
--- a/.changeset/bright-tigers-taste.md
+++ b/.changeset/bright-tigers-taste.md
@@ -1,0 +1,5 @@
+---
+'tailwindcss-flow-type': major
+---
+
+Release V1 with token-based fluid typography, a Tailwind v4 CSS-first preset, and a breaking replacement for the V0 plugin configuration.

--- a/.changeset/bright-tigers-taste.md
+++ b/.changeset/bright-tigers-taste.md
@@ -2,4 +2,9 @@
 'tailwindcss-flow-type': major
 ---
 
-Release V1 with token-based fluid typography, a Tailwind v4 CSS-first preset, and a breaking replacement for the V0 plugin configuration.
+Release V1 with a token-based fluid typography API and Tailwind CSS v4 preset.
+
+- Replace V0 numeric options, `flow-text`, and fixed token lists with modular or explicit typography tokens.
+- Import `tailwindcss-flow-type/preset/default.css` for `text-body`, `text-heading`, and `text-display`.
+- Configure modular tokens in CSS with `--flow-token-*` and optional `--flow-line-height-*` theme variables.
+- Use `namespace` for custom utility names and `replaceDefaultTextScale` to explicitly replace Tailwind's built-in text scale.

--- a/README.md
+++ b/README.md
@@ -1,181 +1,73 @@
-![banner.png](.idea%2Fbanner.png)
+# tailwindcss-flow-type
 
-<h1 align="center">
-  tailwindcss-flow-type
-</h1>
+Fluid typography tokens for Tailwind CSS v4.
 
-<p align="center">
-  A Tailwind CSS plugin for fluid, responsive typography that scales smoothly across screen sizes with minimal configuration.
-</p>
-
-<p align="center">
-    <a href="https://www.npmjs.com/package/tailwindcss-flow-type" rel="nofollow">
-        <img src="https://img.shields.io/npm/v/tailwindcss-flow-type?style=flat-square" alt="npm" style="max-width: 100%;">
-    </a>
-    <a href="https://github.com/MarioMH8/tailwindcss-flow-type">
-        <img src="https://img.shields.io/github/issues/mariomh8/tailwindcss-flow-type?style=flat-square" alt="GitHub issues" style="max-width: 100%;">
-    </a>
-</p>
-
-## Table of Contents
-
-- [Installation](#installation)
-- [Usage](#usage)
-- [Configuration](#configuration)
-- [Contributing](#contributing)
+V1 provides fluid `clamp()` values that respond to the viewport without runtime JavaScript. Use the CSS-first preset for the standard semantic scale, or the JavaScript plugin for a custom modular or explicit token system.
 
 ## Installation
 
-> This plugin requires Tailwind CSS 4 or higher.
-
 ```bash
-npm install --save tailwindcss-flow-type
+npm install tailwindcss-flow-type
 ```
 
-**Using bun**
+## CSS-first preset
 
-```bash
-bun add tailwindcss-flow-type
-```
-
-Include the plugin in your `.css` file:
+The default preset is the simplest Tailwind v4 integration:
 
 ```css
-@import 'tailwindcss';
-
-@plugin 'tailwindcss-flow-type';
+@import "tailwindcss";
+@import "tailwindcss-flow-type/preset/default.css";
 ```
 
-## Usage
-
-The default behavior of the plugin don't override the default `text-*` classes provided by Tailwind CSS. Instead, it
-adds a new set of `flow-*` classes that you can use to apply fluid typography styles.
+It defines `text-body`, `text-heading`, and `text-display`:
 
 ```html
-<article>
-    <h1 class="flow-text-base">Fluid type</h1>
-</article>
+<p class="text-body">Fluid body text</p>
+<h2 class="text-heading">Fluid heading</h2>
+<h1 class="text-display leading-none">Fluid display text</h1>
 ```
 
-```css
-.flow-text-base {
-    font-size: clamp(1.125rem, calc(1.125rem + ((1.25 - 1.125) * ((100vw - 20rem) / (96 - 20)))), 1.25rem);
-}
-.flow-text-base {
-    line-height: 1.6;
-}
-```
+Each value is dynamic in the browser through `clamp()`, while its limits are fixed at build time. For example, `text-body` grows from `1rem` to `1.25rem` between `20rem` and `96rem` viewport widths.
 
-**Override default classes**
+## JavaScript plugin
 
-You can override the default `text-*` classes by setting the `override` option to `true` when configuring the plugin:
+Use the plugin when a project needs its own scale or tokens:
 
-```css
-@import 'tailwindcss';
+```text
+import flowType from "tailwindcss-flow-type";
 
-@plugin 'tailwindcss-flow-type' {
-    override: true
+export default {
+  plugins: [
+    flowType({
+      namespace: "text",
+      replaceDefaultTextScale: false,
+      scale: {
+        viewport: { min: "20rem", max: "96rem" },
+        base: { min: "1rem", max: "1.25rem" },
+        ratio: { min: 1.125, max: 1.2 },
+      },
+      tokens: {
+        body: { scale: 0, lineHeight: "1.6" },
+        heading: { scale: 3, lineHeight: "1.15" },
+        display: {
+          size: { min: "3rem", max: "7rem" },
+          lineHeight: { min: "0.9", max: "1" },
+          letterSpacing: "-0.04em",
+        },
+      },
+    }),
+  ],
 };
 ```
 
-Then you can use the `text-*` classes to apply fluid typography styles:
+`scale` derives a token from the modular exponent. `size` defines an explicit fluid range. A token must use exactly one of them.
 
-```html
-<article>
-    <h1 class="text-base">Fluid type</h1>
-</article>
-```
+Set `namespace: "flow-text"` to emit `flow-text-body`, `flow-text-heading`, and similar utilities instead. Set `replaceDefaultTextScale: true` only when the project intends to replace Tailwind's standard `text-xs` through `text-9xl` utilities.
 
-```css
-.text-base {
-    font-size: clamp(1.125rem, calc(1.125rem + ((1.25 - 1.125) * ((100vw - 20rem) / (96 - 20)))), 1.25rem);
-    line-height: var(--tw-leading, 1.6);
-}
-```
+## Migration from 0.1.0
 
-## Configuration
+See [the V1 migration guide](./docs/migration-v1.md) for the removed V0 options, theme namespaces, and the replacement API.
 
-The plugin comes with a default configuration (see below) but it's possible to customize this config for your project.
-As default, we use `rem` for better accessibility, but you can also use `px`.
+## License
 
-```css
-@import 'tailwindcss';
-
-@plugin 'tailwindcss-flow-type' {
-    fontSizeMax: 1.25;
-    fontSizeMin: 1.125;
-    override: true;
-    prefix: flow;
-    ratioMax: 1.2;
-    ratioMin: 1.125;
-    screenMax: 96;
-    screenMin: 20;
-    unit: rem;
-};
-
-@theme {
-    --flow-text-xs: -2;
-    --flow-text-sm: -1;
-    --flow-text-base: 0;
-    --flow-text-lg: 1;
-    --flow-text-xl: 2;
-    --flow-text-2xl: 3;
-    --flow-text-3xl: 4;
-    --flow-text-4xl: 5;
-    --flow-text-5xl: 6;
-    --flow-text-6xl: 7;
-    --flow-text-7xl: 8;
-    --flow-text-8xl: 9;
-    --flow-text-9xl: 10;
-
-    --flow-line-height-xs: 1.6;
-    --flow-line-height-sm: 1.6;
-    --flow-line-height-base: 1.6;
-    --flow-line-height-lg: 1.6;
-    --flow-line-height-xl: 1.2;
-    --flow-line-height-2xl: 1.2;
-    --flow-line-height-3xl: 1.2;
-    --flow-line-height-4xl: 1.1;
-    --flow-line-height-5xl: 1.1;
-    --flow-line-height-6xl: 1.1;
-    --flow-line-height-7xl: 1;
-    --flow-line-height-8xl: 1;
-    --flow-line-height-9xl: 1;
-}
-```
-
-## Contributing
-
-This project uses [Bun](https://bun.sh) as a runtime, test runner and bundler.
-
-Thanks for wanting to help out! Here's the setup you'll have to do:
-
-Clone the project
-
-```bash
-git clone git@github.com:MarioMH8/tailwindcss-flow-type.git
-```
-
-Go to the project directory
-
-```bash
-cd tailwindcss-flow-type
-```
-
-Install dependencies
-
-```bash
-bun install
-```
-
-Compile the project
-
-```bash
-bun run build
-```
-
-You can read the full [contribution](./CONTRIBUTING.md) guidelines.
-
-## MIT License
-
-[Copyright 2021-2025 MarioMH](./LICENSE)
+MIT

--- a/README.md
+++ b/README.md
@@ -1,73 +1,163 @@
-# tailwindcss-flow-type
+![banner.png](.idea%2Fbanner.png)
 
-Fluid typography tokens for Tailwind CSS v4.
+<h1 align="center">
+  tailwindcss-flow-type
+</h1>
 
-V1 provides fluid `clamp()` values that respond to the viewport without runtime JavaScript. Use the CSS-first preset for the standard semantic scale, or the JavaScript plugin for a custom modular or explicit token system.
+<p align="center">
+  Fluid, responsive typography tokens for Tailwind CSS v4.
+</p>
+
+<p align="center">
+  <a href="https://www.npmjs.com/package/tailwindcss-flow-type" rel="nofollow">
+    <img src="https://img.shields.io/npm/v/tailwindcss-flow-type?style=flat-square" alt="npm" style="max-width: 100%;">
+  </a>
+  <a href="https://github.com/MarioMH8/tailwindcss-flow-type">
+    <img src="https://img.shields.io/github/issues/mariomh8/tailwindcss-flow-type?style=flat-square" alt="GitHub issues" style="max-width: 100%;">
+  </a>
+</p>
+
+## Table of Contents
+
+- [Installation](#installation)
+- [Usage](#usage)
+- [Configuration](#configuration)
+- [Migration](#migration)
+- [Contributing](#contributing)
 
 ## Installation
+
+> This package requires Tailwind CSS 4 or higher.
 
 ```bash
 npm install tailwindcss-flow-type
 ```
 
-## CSS-first preset
+**Using Bun**
 
-The default preset is the simplest Tailwind v4 integration:
+```bash
+bun add tailwindcss-flow-type
+```
+
+## Usage
+
+### CSS-first preset
+
+Import the preset to use the default semantic tokens without registering the JavaScript plugin:
 
 ```css
-@import "tailwindcss";
-@import "tailwindcss-flow-type/preset/default.css";
+@import 'tailwindcss';
+@import 'tailwindcss-flow-type/preset/default.css';
 ```
-
-It defines `text-body`, `text-heading`, and `text-display`:
 
 ```html
-<p class="text-body">Fluid body text</p>
-<h2 class="text-heading">Fluid heading</h2>
-<h1 class="text-display leading-none">Fluid display text</h1>
+<article>
+  <p class="text-body">Fluid body text</p>
+  <h2 class="text-heading">Fluid heading</h2>
+  <h1 class="text-display leading-none">Fluid display text</h1>
+</article>
 ```
 
-Each value is dynamic in the browser through `clamp()`, while its limits are fixed at build time. For example, `text-body` grows from `1rem` to `1.25rem` between `20rem` and `96rem` viewport widths.
+The preset provides `text-body`, `text-heading`, and `text-display`. Each token uses `clamp()`, so it responds to the viewport in the browser without runtime JavaScript.
 
-## JavaScript plugin
+### JavaScript plugin
 
-Use the plugin when a project needs its own scale or tokens:
+Use the plugin when the project needs a custom scale, explicit token sizes, or a custom utility namespace:
 
 ```text
-import flowType from "tailwindcss-flow-type";
+import flowType from 'tailwindcss-flow-type';
 
-export default {
+const config = {
   plugins: [
     flowType({
-      namespace: "text",
+      namespace: 'text',
       replaceDefaultTextScale: false,
       scale: {
-        viewport: { min: "20rem", max: "96rem" },
-        base: { min: "1rem", max: "1.25rem" },
-        ratio: { min: 1.125, max: 1.2 },
+        base: { max: '1.25rem', min: '1rem' },
+        ratio: { max: 1.2, min: 1.125 },
+        viewport: { max: '96rem', min: '20rem' },
       },
       tokens: {
-        body: { scale: 0, lineHeight: "1.6" },
-        heading: { scale: 3, lineHeight: "1.15" },
+        body: { lineHeight: '1.6', scale: 0 },
+        heading: { lineHeight: '1.15', scale: 3 },
         display: {
-          size: { min: "3rem", max: "7rem" },
-          lineHeight: { min: "0.9", max: "1" },
-          letterSpacing: "-0.04em",
+          letterSpacing: '-0.04em',
+          lineHeight: { max: '1', min: '0.9' },
+          size: { max: '7rem', min: '3rem' },
         },
       },
     }),
   ],
 };
+
+export default config;
 ```
 
-`scale` derives a token from the modular exponent. `size` defines an explicit fluid range. A token must use exactly one of them.
+## Configuration
 
-Set `namespace: "flow-text"` to emit `flow-text-body`, `flow-text-heading`, and similar utilities instead. Set `replaceDefaultTextScale: true` only when the project intends to replace Tailwind's standard `text-xs` through `text-9xl` utilities.
+### CSS token configuration
 
-## Migration from 0.1.0
+The JavaScript plugin accepts flat options through `@plugin`. Define modular tokens in CSS with `@theme` using `--flow-token-*`; their value is the exponent in the configured modular scale. Add a matching `--flow-line-height-*` variable when the token needs a default line-height.
 
-See [the V1 migration guide](./docs/migration-v1.md) for the removed V0 options, theme namespaces, and the replacement API.
+```css
+@import 'tailwindcss';
 
-## License
+@plugin 'tailwindcss-flow-type' {
+  namespace: flow-text;
+}
 
-MIT
+@theme {
+  --flow-token-body: 0;
+  --flow-token-heading: 3;
+  --flow-token-display: 6;
+
+  --flow-line-height-body: 1.6;
+  --flow-line-height-heading: 1.15;
+  --flow-line-height-display: 1;
+}
+```
+
+This produces `flow-text-body`, `flow-text-heading`, and `flow-text-display`. CSS-defined tokens override tokens with the same name from the plugin defaults.
+
+### Plugin options
+
+| Option | Type | Default | Description |
+|---|---|---|---|
+| `namespace` | `string` | `text` | Utility namespace. `flow-text` produces `flow-text-body`. |
+| `replaceDefaultTextScale` | `boolean` | `false` | Enables replacement of Tailwind's `text-xs` through `text-9xl` utilities. |
+| `scale.base` | `{ min, max }` | `1rem` to `1.25rem` | Base font-size range for modular tokens. |
+| `scale.ratio` | `{ min, max }` | `1.125` to `1.2` | Modular ratio range. Both values must be positive finite numbers. |
+| `scale.viewport` | `{ min, max }` | `20rem` to `96rem` | Viewport range used by fluid interpolation. |
+| `tokens` | `Record<string, token>` | Built-in semantic scale | JavaScript token definitions. |
+
+Each JavaScript token must define exactly one source for `font-size`:
+
+| Token property | Meaning |
+|---|---|
+| `scale` | Numeric modular exponent, for example `3`. |
+| `size` | Explicit `{ min, max }` CSS values. |
+| `lineHeight` | Fixed string or explicit fluid `{ min, max }` range. |
+| `letterSpacing` | Fixed CSS letter-spacing value. |
+
+Use `replaceDefaultTextScale: true` only when the project intentionally redefines Tailwind's built-in text scale. By default, the package adds semantic tokens and leaves Tailwind's `text-base`, `text-lg`, and similar utilities intact.
+
+## Migration
+
+V1 replaces the V0 options and theme namespaces. Read the complete [V1 migration guide](./docs/migration-v1.md) before upgrading.
+
+## Contributing
+
+This project uses [Bun](https://bun.sh) as its runtime, test runner, and bundler.
+
+```bash
+git clone git@github.com:MarioMH8/tailwindcss-flow-type.git
+cd tailwindcss-flow-type
+bun install
+bun run build
+```
+
+Read the full [contribution guidelines](./CONTRIBUTING.md) before opening an issue or pull request.
+
+## MIT License
+
+[Copyright 2021-2026 MarioMH](./LICENSE)

--- a/docs/migration-v1.md
+++ b/docs/migration-v1.md
@@ -1,33 +1,105 @@
-# Migrating to V1
+# Migrating from 0.1.0 to 1.0.0
 
-V1 is the first stable release of `tailwindcss-flow-type` and intentionally replaces the V0 configuration model.
+V1 is the first stable release of `tailwindcss-flow-type`. It intentionally replaces the V0 option model, fixed token list, and separate theme namespaces with cohesive typography tokens.
 
-## Removed API
+## Before upgrading
 
-The following plugin options no longer exist: `fontSizeMin`, `fontSizeMax`, `ratioMin`, `ratioMax`, `screenMin`, `screenMax`, `unit`, `prefix`, and `override`.
+V1 is a breaking release. Upgrade the package and migrate its CSS or JavaScript configuration in the same change. Do not retain V0 `flow-text` or `flow-line-height` variables, because they no longer have an effect.
 
-The `flow-text` and `flow-line-height` theme namespaces are also removed. V1 tokens carry their size, line-height, and letter-spacing together.
+## Replace the plugin configuration
 
-## Replace the V0 plugin
+V0 combined all scale dimensions into numeric values plus a shared `unit`:
 
 ```css
-/* V0 */
-@plugin "tailwindcss-flow-type" {
+@plugin 'tailwindcss-flow-type' {
+  fontSizeMin: 1.125;
+  fontSizeMax: 1.25;
+  ratioMin: 1.125;
+  ratioMax: 1.2;
+  screenMin: 20;
+  screenMax: 96;
+  unit: rem;
+  prefix: flow;
   override: true;
 }
 ```
 
-Use the CSS-first preset when the default semantic tokens are sufficient:
+V1 uses complete CSS values for ranges. For advanced configuration, move the scale to the JavaScript plugin API:
 
-```css
-@import "tailwindcss";
-@import "tailwindcss-flow-type/preset/default.css";
+```text
+flowType({
+  namespace: 'text',
+  replaceDefaultTextScale: true,
+  scale: {
+    base: { max: '1.25rem', min: '1.125rem' },
+    ratio: { max: 1.2, min: 1.125 },
+    viewport: { max: '96rem', min: '20rem' },
+  },
+});
 ```
 
-For a custom system, move configuration to the JavaScript plugin API and define tokens with a modular `scale` exponent or explicit `size` range.
+| V0 | V1 replacement |
+|---|---|
+| `fontSizeMin` / `fontSizeMax` | `scale.base.min` / `scale.base.max` |
+| `ratioMin` / `ratioMax` | `scale.ratio.min` / `scale.ratio.max` |
+| `screenMin` / `screenMax` / `unit` | `scale.viewport.min` / `scale.viewport.max` as complete CSS lengths |
+| `prefix` | `namespace` |
+| `override` | `replaceDefaultTextScale` |
 
-## Default Tailwind scale
+## Replace theme namespaces
 
-V0 used `override` to affect `text-*`. V1 keeps Tailwind's built-in text scale by default and adds semantic tokens such as `text-body` and `text-heading`.
+V0 used separate namespaces:
 
-Set `replaceDefaultTextScale: true` only when intentionally redefining the built-in text scale.
+```css
+@theme {
+  --flow-text-body: 0;
+  --flow-line-height-body: 1.6;
+}
+```
+
+V1 uses `--flow-token-*` for the modular exponent and retains `--flow-line-height-*` for the optional default line-height:
+
+```css
+@plugin 'tailwindcss-flow-type' {
+  namespace: flow-text;
+}
+
+@theme {
+  --flow-token-body: 0;
+  --flow-line-height-body: 1.6;
+}
+```
+
+The V1 example generates `flow-text-body`. Use `namespace: text` to generate `text-body` instead.
+
+## Choose an integration
+
+Use the CSS-first preset when the built-in semantic tokens are enough:
+
+```css
+@import 'tailwindcss';
+@import 'tailwindcss-flow-type/preset/default.css';
+```
+
+The preset provides `text-body`, `text-heading`, and `text-display` without registering `@plugin`.
+
+Use the JavaScript plugin when a token needs an explicit range, such as a display style that does not follow the modular scale:
+
+```text
+display: {
+  letterSpacing: '-0.04em',
+  lineHeight: { max: '1', min: '0.9' },
+  size: { max: '7rem', min: '3rem' },
+}
+```
+
+## Default Tailwind text scale
+
+V0's `override: true` changed the behavior of built-in `text-*` utilities. V1 leaves Tailwind's standard scale untouched by default and adds semantic tokens. Set `replaceDefaultTextScale: true` only when a project deliberately wants to replace `text-xs` through `text-9xl`.
+
+## Verify the migration
+
+1. Replace every V0 plugin option and `--flow-text-*` variable.
+2. Compile the stylesheet and verify that the expected `text-*` or custom namespace classes are generated.
+3. Check the smallest and largest supported viewport widths to confirm each `clamp()` reaches the intended values.
+4. Remove obsolete V0 snapshots or custom CSS that targeted its old utility names.

--- a/docs/migration-v1.md
+++ b/docs/migration-v1.md
@@ -1,0 +1,33 @@
+# Migrating to V1
+
+V1 is the first stable release of `tailwindcss-flow-type` and intentionally replaces the V0 configuration model.
+
+## Removed API
+
+The following plugin options no longer exist: `fontSizeMin`, `fontSizeMax`, `ratioMin`, `ratioMax`, `screenMin`, `screenMax`, `unit`, `prefix`, and `override`.
+
+The `flow-text` and `flow-line-height` theme namespaces are also removed. V1 tokens carry their size, line-height, and letter-spacing together.
+
+## Replace the V0 plugin
+
+```css
+/* V0 */
+@plugin "tailwindcss-flow-type" {
+  override: true;
+}
+```
+
+Use the CSS-first preset when the default semantic tokens are sufficient:
+
+```css
+@import "tailwindcss";
+@import "tailwindcss-flow-type/preset/default.css";
+```
+
+For a custom system, move configuration to the JavaScript plugin API and define tokens with a modular `scale` exponent or explicit `size` range.
+
+## Default Tailwind scale
+
+V0 used `override` to affect `text-*`. V1 keeps Tailwind's built-in text scale by default and adds semantic tokens such as `text-body` and `text-heading`.
+
+Set `replaceDefaultTextScale: true` only when intentionally redefining the built-in text scale.

--- a/e2e/index.test.ts
+++ b/e2e/index.test.ts
@@ -20,6 +20,17 @@ describe('tailwindcss-flow-type', () => {
 		expect(css).toContain('font-size: clamp(1rem, calc(1rem + (1.25rem - 1rem)');
 	});
 
+	it('should resolve modular tokens declared through CSS theme variables', async () => {
+		const css = await generateCss('test-2.html', {
+			options: '{ namespace: flow-text; }',
+			theme: '--flow-token-body: 1; --flow-line-height-body: 1.4;',
+		});
+
+		expect(css).toContain('.flow-text-body');
+		expect(css).toContain('font-size: clamp(1.125rem, calc(1.125rem + (1.5rem - 1.125rem)');
+		expect(css).toContain('line-height: 1.4');
+	});
+
 	it('should replace default text utilities only when configured', async () => {
 		const css = await generateCss('test-3.html', {
 			options: '{ replaceDefaultTextScale: true; }',

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -85,18 +85,52 @@ function shouldReplaceDefaultTextScale(value: unknown): boolean {
 	return typeof value === 'boolean' ? value : DEFAULT_FLOW_TYPE_OPTIONS.replaceDefaultTextScale;
 }
 
+function createCssThemeTokens(flowTokens: unknown, flowLineHeights: unknown): Record<string, FlowTypographyToken> {
+	if (typeof flowTokens !== 'object' || flowTokens === null || Array.isArray(flowTokens)) {
+		return {};
+	}
+
+	const lineHeights: Record<string, unknown> =
+		typeof flowLineHeights === 'object' && flowLineHeights !== null && !Array.isArray(flowLineHeights)
+			? (flowLineHeights as Record<string, unknown>)
+			: {};
+	const tokens: Record<string, FlowTypographyToken> = {};
+
+	for (const [name, value] of Object.entries(flowTokens)) {
+		const scale = Number(value);
+
+		if (!Number.isFinite(scale)) {
+			continue;
+		}
+
+		const lineHeight = lineHeights[name];
+		tokens[name] = {
+			...(typeof lineHeight === 'string' && lineHeight.length > 0 && { lineHeight }),
+			scale,
+		};
+	}
+
+	return tokens;
+}
+
 function createFlowTypePlugin(userOptions: FlowTypePluginUserOptions = {}): PluginCreator {
 	const options = parseFlowTypePluginOptions(userOptions);
-	const tokens = Object.fromEntries(
-		Object.entries(options.tokens).filter(([name]) =>
-			options.namespace === 'text' && !options.replaceDefaultTextScale
-				? !TAILWIND_TEXT_TOKEN_NAMES.includes(name as (typeof TAILWIND_TEXT_TOKEN_NAMES)[number])
-				: true
-		)
-	);
-	const values = Object.fromEntries(Object.keys(tokens).map(name => [name, name]));
 
 	return (api: PluginAPI) => {
+		const configuredTokens = {
+			...options.tokens,
+			...createCssThemeTokens(api.theme('flow-token'), api.theme('flow-line-height')),
+		};
+		const tokenEntries = Object.entries(configuredTokens);
+		const tokens = Object.fromEntries(
+			tokenEntries.filter(([name]) =>
+				options.namespace === 'text' && !options.replaceDefaultTextScale
+					? !TAILWIND_TEXT_TOKEN_NAMES.includes(name as (typeof TAILWIND_TEXT_TOKEN_NAMES)[number])
+					: true
+			)
+		);
+		const values = Object.fromEntries(Object.keys(tokens).map(name => [name, name]));
+
 		api.matchUtilities(
 			{
 				[options.namespace]: (tokenName: string) => {


### PR DESCRIPTION
## Summary

- restore the project's structured README, including installation, usage, configuration, and contribution sections
- document and implement CSS-defined modular tokens through `--flow-token-*` and `--flow-line-height-*`
- expand the `0.1.0 -> 1.0.0` migration guide with option mapping, namespace migration, and verification steps
- improve the single major changeset with the changelog-ready migration summary

## Verification

- `bun run lint`
- `bun run typecheck`
- `bun run test`

Closes #118

Part of #115.