### PR TITLE
feat(css)!: support full CSS typography configuration

### DIFF
--- a/.changeset/bright-tigers-taste.md
+++ b/.changeset/bright-tigers-taste.md
@@ -7,4 +7,4 @@ Release V1 with a token-based fluid typography API and Tailwind CSS v4 preset.
 - Replace V0 numeric options, `flow-text`, and fixed token lists with modular or explicit typography tokens.
 - Import `tailwindcss-flow-type/preset/default.css` for `text-body`, `text-heading`, and `text-display`.
 - Configure modular tokens in CSS with `--flow-token-*` and optional `--flow-line-height-*` theme variables.
-- Use `namespace` for custom utility names and `replaceDefaultTextScale` to explicitly replace Tailwind's built-in text scale.
+- Use `namespace` for custom utility names and `replaceDefaultTextScale` to explicitly replace Tailwind's built-in text scale with overridable fluid defaults.

--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ This produces `flow-text-body`, `flow-text-heading`, and `flow-text-display`. CS
 | Option                    | Type                    | Default                 | Description                                                               |
 |---------------------------|-------------------------|-------------------------|---------------------------------------------------------------------------|
 | `namespace`               | `string`                | `text`                  | Utility namespace. `flow-text` produces `flow-text-body`.                 |
-| `replaceDefaultTextScale` | `boolean`               | `false`                 | Enables replacement of Tailwind's `text-xs` through `text-9xl` utilities. |
+| `replaceDefaultTextScale` | `boolean`               | `false`                 | Replaces Tailwind's `text-xs` through `text-9xl` utilities with the bundled fluid scale. |
 | `scale.base`              | `{ min, max }`          | `1rem` to `1.25rem`     | Base font-size range for modular tokens.                                  |
 | `scale.ratio`             | `{ min, max }`          | `1.125` to `1.2`        | Modular ratio range. Both values must be positive finite numbers.         |
 | `scale.viewport`          | `{ min, max }`          | `20rem` to `96rem`      | Viewport range used by fluid interpolation.                               |
@@ -139,7 +139,7 @@ Each JavaScript token must define exactly one source for `font-size`:
 | `lineHeight`    | Fixed string or explicit fluid `{ min, max }` range. |
 | `letterSpacing` | Fixed CSS letter-spacing value.                      |
 
-Use `replaceDefaultTextScale: true` only when the project intentionally redefines Tailwind's built-in text scale. By default, the plugin emits no utilities and leaves Tailwind's `text-base`, `text-lg`, and similar utilities intact.
+Use `replaceDefaultTextScale: true` only when the project intentionally redefines Tailwind's built-in text scale. It enables bundled fluid values for `text-xs` through `text-9xl`; JavaScript or CSS tokens with the same name override them. By default, the plugin emits no utilities and leaves Tailwind's `text-base`, `text-lg`, and similar utilities intact.
 
 ## Migration
 

--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ export default config;
 
 ### CSS token configuration
 
-The JavaScript plugin accepts flat options through `@plugin`. Define modular tokens in CSS with `@theme` using `--flow-token-*`; their value is the exponent in the configured modular scale. Add a matching `--flow-line-height-*` variable when the token needs a default line-height.
+Tailwind's `@plugin` directive accepts only flat declarations. It can configure the utility namespace and whether to replace Tailwind's standard text scale. Define modular tokens in CSS with `@theme` using `--flow-token-*`; their value is the exponent in the configured modular scale. Add a matching `--flow-line-height-*` variable when the token needs a default line-height.
 
 ```css
 @import 'tailwindcss';
@@ -119,7 +119,32 @@ The JavaScript plugin accepts flat options through `@plugin`. Define modular tok
 
 This produces `flow-text-body`, `flow-text-heading`, and `flow-text-display`. CSS-defined tokens override JavaScript tokens with the same name.
 
-### Plugin options
+#### CSS configuration surface
+
+| Need | CSS API | Notes |
+|---|---|---|
+| Custom utility namespace | `@plugin { namespace: flow-text; }` | Produces `flow-text-*` classes. |
+| Replace `text-xs` through `text-9xl` | `@plugin { replaceDefaultTextScale: true; }` | Uses the bundled fluid replacement scale. |
+| Modular token | `--flow-token-name: exponent` | The exponent is a finite number, for example `3`. |
+| Token line-height | `--flow-line-height-name: value` | Optional fixed CSS value. |
+| Custom scale, explicit size, fluid line-height, or letter-spacing | Not supported in CSS | Use the JavaScript plugin API. |
+
+For example, this opt-in configuration replaces Tailwind's default `text-base`, then overrides that token from CSS:
+
+```css
+@plugin 'tailwindcss-flow-type' {
+  replaceDefaultTextScale: true;
+}
+
+@theme {
+  --flow-token-base: 1;
+  --flow-line-height-base: 1.4;
+}
+```
+
+### JavaScript plugin options
+
+Use JavaScript configuration when the scale itself must change or a token cannot be described by a modular exponent. Tailwind cannot pass nested objects through `@plugin`, which is why this surface is TypeScript-only.
 
 | Option                    | Type                    | Default                 | Description                                                               |
 |---------------------------|-------------------------|-------------------------|---------------------------------------------------------------------------|

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ The preset provides `text-body`, `text-heading`, and `text-display`. Each token 
 
 ### JavaScript plugin
 
-Use the plugin when the project needs a custom scale, explicit token sizes, or a custom utility namespace:
+Use the plugin when the project needs a custom scale, explicit token sizes, or a custom utility namespace. It emits no typography utilities until the project defines at least one token.
 
 ```typescript
 import flowType from 'tailwindcss-flow-type';
@@ -117,7 +117,7 @@ The JavaScript plugin accepts flat options through `@plugin`. Define modular tok
 }
 ```
 
-This produces `flow-text-body`, `flow-text-heading`, and `flow-text-display`. CSS-defined tokens override tokens with the same name from the plugin defaults.
+This produces `flow-text-body`, `flow-text-heading`, and `flow-text-display`. CSS-defined tokens override JavaScript tokens with the same name.
 
 ### Plugin options
 
@@ -128,7 +128,7 @@ This produces `flow-text-body`, `flow-text-heading`, and `flow-text-display`. CS
 | `scale.base`              | `{ min, max }`          | `1rem` to `1.25rem`     | Base font-size range for modular tokens.                                  |
 | `scale.ratio`             | `{ min, max }`          | `1.125` to `1.2`        | Modular ratio range. Both values must be positive finite numbers.         |
 | `scale.viewport`          | `{ min, max }`          | `20rem` to `96rem`      | Viewport range used by fluid interpolation.                               |
-| `tokens`                  | `Record<string, token>` | Built-in semantic scale | JavaScript token definitions.                                             |
+| `tokens`                  | `Record<string, token>` | None                    | JavaScript token definitions.                                             |
 
 Each JavaScript token must define exactly one source for `font-size`:
 
@@ -139,7 +139,7 @@ Each JavaScript token must define exactly one source for `font-size`:
 | `lineHeight`    | Fixed string or explicit fluid `{ min, max }` range. |
 | `letterSpacing` | Fixed CSS letter-spacing value.                      |
 
-Use `replaceDefaultTextScale: true` only when the project intentionally redefines Tailwind's built-in text scale. By default, the package adds semantic tokens and leaves Tailwind's `text-base`, `text-lg`, and similar utilities intact.
+Use `replaceDefaultTextScale: true` only when the project intentionally redefines Tailwind's built-in text scale. By default, the plugin emits no utilities and leaves Tailwind's `text-base`, `text-lg`, and similar utilities intact.
 
 ## Migration
 

--- a/README.md
+++ b/README.md
@@ -41,28 +41,25 @@ bun add tailwindcss-flow-type
 
 ## Usage
 
-### CSS-first preset
+### CSS plugin
 
-Import the preset to use the default semantic tokens without registering the JavaScript plugin:
+Define a modular token directly in a CSS stylesheet:
 
 ```css
 @import 'tailwindcss';
-@import 'tailwindcss-flow-type/preset/default.css';
+
+@plugin 'tailwindcss-flow-type';
+
+@theme {
+  --flow-token-body: 0;
+}
 ```
 
 ```html
-<article>
-  <p class="text-body">Fluid body text</p>
-  <h2 class="text-heading">Fluid heading</h2>
-  <h1 class="text-display leading-none">Fluid display text</h1>
-</article>
+<p class="text-body">Fluid body text</p>
 ```
 
-The preset provides `text-body`, `text-heading`, and `text-display`. Each token uses `clamp()`, so it responds to the viewport in the browser without runtime JavaScript.
-
-### JavaScript plugin
-
-Use the plugin when the project needs a custom scale, explicit token sizes, or a custom utility namespace. It emits no typography utilities until the project defines at least one token.
+### TypeScript plugin
 
 ```typescript
 import flowType from 'tailwindcss-flow-type';
@@ -70,21 +67,8 @@ import flowType from 'tailwindcss-flow-type';
 const config = {
   plugins: [
     flowType({
-      namespace: 'text',
-      replaceDefaultTextScale: false,
-      scale: {
-        base: { max: '1.25rem', min: '1rem' },
-        ratio: { max: 1.2, min: 1.125 },
-        viewport: { max: '96rem', min: '20rem' },
-      },
       tokens: {
         body: { lineHeight: '1.6', scale: 0 },
-        display: {
-          letterSpacing: '-0.04em',
-          lineHeight: { max: '1', min: '0.9' },
-          size: { max: '7rem', min: '3rem' },
-        },
-        heading: { lineHeight: '1.15', scale: 3 },
       },
     }),
   ],
@@ -93,15 +77,46 @@ const config = {
 export default config;
 ```
 
-## Configuration
+### CSS-first preset
 
-### CSS token configuration
-
-Tailwind's `@plugin` directive accepts only flat declarations. The plugin normalizes those declarations into the same scale model used by TypeScript. Define tokens in CSS with `@theme` variables.
+Import the preset for the built-in semantic tokens:
 
 ```css
 @import 'tailwindcss';
+@import 'tailwindcss-flow-type/preset/default.css';
+```
 
+```html
+<h1 class="text-display">Fluid display text</h1>
+```
+
+The preset provides `text-body`, `text-heading`, and `text-display`. Each token uses `clamp()`, so it responds to the viewport in the browser without runtime JavaScript.
+
+## Configuration
+
+The CSS and TypeScript APIs configure the same model. CSS uses flat `@plugin` declarations and `@theme` variables; TypeScript uses nested objects.
+
+| Setting | CSS | TypeScript | Default |
+|---|---|---|---|
+| Utility namespace | `namespace: flow-text` | `namespace: 'flow-text'` | `text` |
+| Replace Tailwind text scale | `replace-default-text-scale: true` | `replaceDefaultTextScale: true` | `false` |
+| Base minimum | `scale-base-min: 1rem` | `scale.base.min: '1rem'` | `1rem` |
+| Base maximum | `scale-base-max: 1.25rem` | `scale.base.max: '1.25rem'` | `1.25rem` |
+| Minimum ratio | `scale-ratio-min: 1.125` | `scale.ratio.min: 1.125` | `1.125` |
+| Maximum ratio | `scale-ratio-max: 1.2` | `scale.ratio.max: 1.2` | `1.2` |
+| Minimum viewport | `scale-viewport-min: 20rem` | `scale.viewport.min: '20rem'` | `20rem` |
+| Maximum viewport | `scale-viewport-max: 96rem` | `scale.viewport.max: '96rem'` | `96rem` |
+| Modular token | `--flow-token-name: 3` | `tokens.name.scale: 3` | None |
+| Explicit token size | `--flow-size-name-min` / `--flow-size-name-max` | `tokens.name.size` | None |
+| Fixed line-height | `--flow-line-height-name` | `tokens.name.lineHeight` | None |
+| Fluid line-height | `--flow-line-height-name-min` / `--flow-line-height-name-max` | `tokens.name.lineHeight` | None |
+| Letter-spacing | `--flow-letter-spacing-name` | `tokens.name.letterSpacing` | None |
+
+`replaceDefaultTextScale` enables bundled fluid values for `text-xs` through `text-9xl`. A CSS or TypeScript token with the same name overrides the bundled value. Without an explicit token or replacement scale, the plugin emits no utilities.
+
+### Complete CSS example
+
+```css
 @plugin 'tailwindcss-flow-type' {
   namespace: flow-text;
   scale-base-min: 1rem;
@@ -113,13 +128,8 @@ Tailwind's `@plugin` directive accepts only flat declarations. The plugin normal
 }
 
 @theme {
-  /* Modular tokens */
   --flow-token-body: 0;
-  --flow-token-heading: 3;
   --flow-line-height-body: 1.6;
-  --flow-line-height-heading: 1.15;
-
-  /* Explicit tokens */
   --flow-size-display-min: 3rem;
   --flow-size-display-max: 7rem;
   --flow-line-height-display-min: 0.9;
@@ -128,59 +138,26 @@ Tailwind's `@plugin` directive accepts only flat declarations. The plugin normal
 }
 ```
 
-This produces `flow-text-body`, `flow-text-heading`, and `flow-text-display`. CSS-defined tokens override JavaScript tokens with the same name.
+### Complete TypeScript example
 
-#### CSS configuration surface
-
-| Need | CSS API | Notes |
-|---|---|---|
-| Custom utility namespace | `@plugin { namespace: flow-text; }` | Produces `flow-text-*` classes. |
-| Replace `text-xs` through `text-9xl` | `@plugin { replace-default-text-scale: true; }` | Uses the bundled fluid replacement scale. |
-| Base scale | `scale-base-min` / `scale-base-max` | Complete CSS lengths. |
-| Modular ratios | `scale-ratio-min` / `scale-ratio-max` | Positive finite numbers. |
-| Viewport range | `scale-viewport-min` / `scale-viewport-max` | Complete CSS lengths. |
-| Modular token | `--flow-token-name: exponent` | The exponent is a finite number, for example `3`. |
-| Explicit token size | `--flow-size-name-min` / `--flow-size-name-max` | Both values are required. |
-| Token line-height | `--flow-line-height-name: value` | Optional fixed CSS value. |
-| Fluid token line-height | `--flow-line-height-name-min` / `--flow-line-height-name-max` | Both values are required. |
-| Token letter-spacing | `--flow-letter-spacing-name: value` | Optional fixed CSS value. |
-
-For example, this opt-in configuration replaces Tailwind's default `text-base`, then overrides that token from CSS:
-
-```css
-@plugin 'tailwindcss-flow-type' {
-  replaceDefaultTextScale: true;
-}
-
-@theme {
-  --flow-token-base: 1;
-  --flow-line-height-base: 1.4;
-}
+```typescript
+flowType({
+  namespace: 'flow-text',
+  scale: {
+    base: { max: '1.25rem', min: '1rem' },
+    ratio: { max: 1.2, min: 1.125 },
+    viewport: { max: '96rem', min: '20rem' },
+  },
+  tokens: {
+    body: { lineHeight: '1.6', scale: 0 },
+    display: {
+      letterSpacing: '-0.04em',
+      lineHeight: { max: '1', min: '0.9' },
+      size: { max: '7rem', min: '3rem' },
+    },
+  },
+});
 ```
-
-### JavaScript plugin options
-
-The JavaScript API uses nested objects instead of CSS variables, but exposes the same configuration model. It is useful when configuration belongs in a shared TypeScript file or is generated programmatically.
-
-| Option                    | Type                    | Default                 | Description                                                               |
-|---------------------------|-------------------------|-------------------------|---------------------------------------------------------------------------|
-| `namespace`               | `string`                | `text`                  | Utility namespace. `flow-text` produces `flow-text-body`.                 |
-| `replaceDefaultTextScale` | `boolean`               | `false`                 | Replaces Tailwind's `text-xs` through `text-9xl` utilities with the bundled fluid scale. |
-| `scale.base`              | `{ min, max }`          | `1rem` to `1.25rem`     | Base font-size range for modular tokens.                                  |
-| `scale.ratio`             | `{ min, max }`          | `1.125` to `1.2`        | Modular ratio range. Both values must be positive finite numbers.         |
-| `scale.viewport`          | `{ min, max }`          | `20rem` to `96rem`      | Viewport range used by fluid interpolation.                               |
-| `tokens`                  | `Record<string, token>` | None                    | JavaScript token definitions.                                             |
-
-Each JavaScript token must define exactly one source for `font-size`:
-
-| Token property  | Meaning                                              |
-|-----------------|------------------------------------------------------|
-| `scale`         | Numeric modular exponent, for example `3`.           |
-| `size`          | Explicit `{ min, max }` CSS values.                  |
-| `lineHeight`    | Fixed string or explicit fluid `{ min, max }` range. |
-| `letterSpacing` | Fixed CSS letter-spacing value.                      |
-
-Use `replaceDefaultTextScale: true` only when the project intentionally redefines Tailwind's built-in text scale. It enables bundled fluid values for `text-xs` through `text-9xl`; JavaScript or CSS tokens with the same name override them. By default, the plugin emits no utilities and leaves Tailwind's `text-base`, `text-lg`, and similar utilities intact.
 
 ## Migration
 

--- a/README.md
+++ b/README.md
@@ -97,23 +97,34 @@ export default config;
 
 ### CSS token configuration
 
-Tailwind's `@plugin` directive accepts only flat declarations. It can configure the utility namespace and whether to replace Tailwind's standard text scale. Define modular tokens in CSS with `@theme` using `--flow-token-*`; their value is the exponent in the configured modular scale. Add a matching `--flow-line-height-*` variable when the token needs a default line-height.
+Tailwind's `@plugin` directive accepts only flat declarations. The plugin normalizes those declarations into the same scale model used by TypeScript. Define tokens in CSS with `@theme` variables.
 
 ```css
 @import 'tailwindcss';
 
 @plugin 'tailwindcss-flow-type' {
   namespace: flow-text;
+  scale-base-min: 1rem;
+  scale-base-max: 1.25rem;
+  scale-ratio-min: 1.125;
+  scale-ratio-max: 1.2;
+  scale-viewport-min: 20rem;
+  scale-viewport-max: 96rem;
 }
 
 @theme {
+  /* Modular tokens */
   --flow-token-body: 0;
   --flow-token-heading: 3;
-  --flow-token-display: 6;
-
   --flow-line-height-body: 1.6;
   --flow-line-height-heading: 1.15;
-  --flow-line-height-display: 1;
+
+  /* Explicit tokens */
+  --flow-size-display-min: 3rem;
+  --flow-size-display-max: 7rem;
+  --flow-line-height-display-min: 0.9;
+  --flow-line-height-display-max: 1;
+  --flow-letter-spacing-display: -0.04em;
 }
 ```
 
@@ -124,10 +135,15 @@ This produces `flow-text-body`, `flow-text-heading`, and `flow-text-display`. CS
 | Need | CSS API | Notes |
 |---|---|---|
 | Custom utility namespace | `@plugin { namespace: flow-text; }` | Produces `flow-text-*` classes. |
-| Replace `text-xs` through `text-9xl` | `@plugin { replaceDefaultTextScale: true; }` | Uses the bundled fluid replacement scale. |
+| Replace `text-xs` through `text-9xl` | `@plugin { replace-default-text-scale: true; }` | Uses the bundled fluid replacement scale. |
+| Base scale | `scale-base-min` / `scale-base-max` | Complete CSS lengths. |
+| Modular ratios | `scale-ratio-min` / `scale-ratio-max` | Positive finite numbers. |
+| Viewport range | `scale-viewport-min` / `scale-viewport-max` | Complete CSS lengths. |
 | Modular token | `--flow-token-name: exponent` | The exponent is a finite number, for example `3`. |
+| Explicit token size | `--flow-size-name-min` / `--flow-size-name-max` | Both values are required. |
 | Token line-height | `--flow-line-height-name: value` | Optional fixed CSS value. |
-| Custom scale, explicit size, fluid line-height, or letter-spacing | Not supported in CSS | Use the JavaScript plugin API. |
+| Fluid token line-height | `--flow-line-height-name-min` / `--flow-line-height-name-max` | Both values are required. |
+| Token letter-spacing | `--flow-letter-spacing-name: value` | Optional fixed CSS value. |
 
 For example, this opt-in configuration replaces Tailwind's default `text-base`, then overrides that token from CSS:
 
@@ -144,7 +160,7 @@ For example, this opt-in configuration replaces Tailwind's default `text-base`, 
 
 ### JavaScript plugin options
 
-Use JavaScript configuration when the scale itself must change or a token cannot be described by a modular exponent. Tailwind cannot pass nested objects through `@plugin`, which is why this surface is TypeScript-only.
+The JavaScript API uses nested objects instead of CSS variables, but exposes the same configuration model. It is useful when configuration belongs in a shared TypeScript file or is generated programmatically.
 
 | Option                    | Type                    | Default                 | Description                                                               |
 |---------------------------|-------------------------|-------------------------|---------------------------------------------------------------------------|

--- a/docs/migration-v1.md
+++ b/docs/migration-v1.md
@@ -95,7 +95,7 @@ display: {
 
 ## Default Tailwind text scale
 
-V0's `override: true` changed the behavior of built-in `text-*` utilities. V1 leaves Tailwind's standard scale untouched and emits no plugin utilities until tokens are defined. Set `replaceDefaultTextScale: true` only when a project deliberately wants to replace `text-xs` through `text-9xl`.
+V0's `override: true` changed the behavior of built-in `text-*` utilities. V1 leaves Tailwind's standard scale untouched and emits no plugin utilities until tokens are defined. Set `replaceDefaultTextScale: true` to deliberately replace `text-xs` through `text-9xl` with the bundled fluid scale; CSS or JavaScript tokens with matching names override the bundled values.
 
 ## Verify the migration
 

--- a/docs/migration-v1.md
+++ b/docs/migration-v1.md
@@ -95,7 +95,7 @@ display: {
 
 ## Default Tailwind text scale
 
-V0's `override: true` changed the behavior of built-in `text-*` utilities. V1 leaves Tailwind's standard scale untouched by default and adds semantic tokens. Set `replaceDefaultTextScale: true` only when a project deliberately wants to replace `text-xs` through `text-9xl`.
+V0's `override: true` changed the behavior of built-in `text-*` utilities. V1 leaves Tailwind's standard scale untouched and emits no plugin utilities until tokens are defined. Set `replaceDefaultTextScale: true` only when a project deliberately wants to replace `text-xs` through `text-9xl`.
 
 ## Verify the migration
 

--- a/e2e/index.test.ts
+++ b/e2e/index.test.ts
@@ -2,22 +2,11 @@ import generateCss from '@e2e/utils/generate-css';
 import { describe, expect, it } from 'bun:test';
 
 describe('tailwindcss-flow-type', () => {
-	it('should generate semantic text utilities by default', async () => {
+	it('should not generate utilities without explicit tokens', async () => {
 		const css = await generateCss('test-1.html');
 
-		expect(css).toContain('.text-body');
-		expect(css).toContain('.text-heading');
-		expect(css).toContain('font-size: clamp(1rem, calc(1rem + (1.25rem - 1rem)');
-		expect(css).toContain('line-height: 1.6');
-	});
-
-	it('should support a custom utility namespace', async () => {
-		const css = await generateCss('test-2.html', {
-			options: '{ namespace: flow-text; }',
-		});
-
-		expect(css).toContain('.flow-text-body');
-		expect(css).toContain('font-size: clamp(1rem, calc(1rem + (1.25rem - 1rem)');
+		expect(css).not.toContain('.text-body');
+		expect(css).not.toContain('.text-heading');
 	});
 
 	it('should resolve modular tokens declared through CSS theme variables', async () => {
@@ -34,6 +23,7 @@ describe('tailwindcss-flow-type', () => {
 	it('should replace default text utilities only when configured', async () => {
 		const css = await generateCss('test-3.html', {
 			options: '{ replaceDefaultTextScale: true; }',
+			theme: '--flow-token-base: 0;',
 		});
 
 		expect(css).toContain('.text-base');

--- a/e2e/index.test.ts
+++ b/e2e/index.test.ts
@@ -20,12 +20,51 @@ describe('tailwindcss-flow-type', () => {
 		expect(css).toContain('line-height: 1.4');
 	});
 
+	it('should resolve flat CSS scale options', async () => {
+		const css = await generateCss('test-2.html', {
+			options: `{
+        namespace: flow-text;
+        scale-base-min: 2rem;
+        scale-base-max: 3rem;
+        scale-ratio-min: 1;
+        scale-ratio-max: 1;
+        scale-viewport-min: 30rem;
+        scale-viewport-max: 90rem;
+      }`,
+			theme: '--flow-token-body: 1;',
+		});
+
+		expect(css).toContain(
+			'font-size: clamp(2rem, calc(2rem + (3rem - 2rem) * ((100vw - 30rem) / (90rem - 30rem)))'
+		);
+	});
+
+	it('should resolve explicit CSS token properties', async () => {
+		const css = await generateCss('test-2.html', {
+			options: '{ namespace: flow-text; }',
+			theme: `
+        --flow-size-display-min: 3rem;
+        --flow-size-display-max: 7rem;
+        --flow-line-height-display-min: 0.9;
+        --flow-line-height-display-max: 1;
+        --flow-letter-spacing-display: -0.04em;
+      `,
+		});
+
+		expect(css).toContain('.flow-text-display');
+		expect(css).toContain('font-size: clamp(3rem, calc(3rem + (7rem - 3rem)');
+		expect(css).toContain('line-height: clamp(0.9, calc(0.9 + (1 - 0.9)');
+		expect(css).toContain('letter-spacing: -0.04em');
+	});
+
 	it('should replace default text utilities only when configured', async () => {
 		const css = await generateCss('test-3.html', {
 			options: '{ replaceDefaultTextScale: true; }',
 		});
 
 		expect(css).toContain('.text-base');
+		expect(css).toContain('.text-lg');
+		expect(css).toContain('.text-xl');
 		expect(css).toContain('font-size: clamp(1rem, calc(1rem + (1.25rem - 1rem)');
 	});
 

--- a/e2e/index.test.ts
+++ b/e2e/index.test.ts
@@ -23,11 +23,21 @@ describe('tailwindcss-flow-type', () => {
 	it('should replace default text utilities only when configured', async () => {
 		const css = await generateCss('test-3.html', {
 			options: '{ replaceDefaultTextScale: true; }',
-			theme: '--flow-token-base: 0;',
 		});
 
 		expect(css).toContain('.text-base');
 		expect(css).toContain('font-size: clamp(1rem, calc(1rem + (1.25rem - 1rem)');
+	});
+
+	it('should let CSS tokens override the replacement scale', async () => {
+		const css = await generateCss('test-3.html', {
+			options: '{ replaceDefaultTextScale: true; }',
+			theme: '--flow-token-base: 1; --flow-line-height-base: 1.4;',
+		});
+
+		expect(css).toContain('.text-base');
+		expect(css).toContain('font-size: clamp(1.125rem, calc(1.125rem + (1.5rem - 1.125rem)');
+		expect(css).toContain('line-height: 1.4');
 	});
 
 	it('should generate semantic text utilities from the CSS-first preset', async () => {

--- a/e2e/test-2.html
+++ b/e2e/test-2.html
@@ -1,2 +1,3 @@
 <h1 class='flow-text-heading'></h1>
 <p class='flow-text-body'></p>
+<h1 class='flow-text-display'></h1>

--- a/e2e/test-3.html
+++ b/e2e/test-3.html
@@ -1,1 +1,3 @@
 <p class='text-base'></p>
+<p class='text-lg'></p>
+<p class='text-xl'></p>

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -26,28 +26,7 @@ const DEFAULT_FLOW_SCALE: FlowScale = {
 	viewport: { max: '96rem', min: '20rem' },
 };
 
-const DEFAULT_FLOW_TOKENS: Record<string, FlowTypographyToken> = {
-	'2xl': { lineHeight: '1.5', scale: 3 },
-	'3xl': { lineHeight: '1.5', scale: 4 },
-	'4xl': { lineHeight: '1.5', scale: 5 },
-	'5xl': { lineHeight: '1.4', scale: 6 },
-	'6xl': { lineHeight: '1.4', scale: 7 },
-	'7xl': { lineHeight: '1.4', scale: 8 },
-	'8xl': { lineHeight: '1.4', scale: 9 },
-	'9xl': { lineHeight: '1.3', scale: 10 },
-	base: { lineHeight: '1.6', scale: 0 },
-	body: { lineHeight: '1.6', scale: 0 },
-	display: {
-		letterSpacing: '-0.04em',
-		lineHeight: { max: '1', min: '0.9' },
-		size: { max: '7rem', min: '3rem' },
-	},
-	heading: { letterSpacing: '-0.02em', lineHeight: '1.15', scale: 3 },
-	lg: { lineHeight: '1.6', scale: 1 },
-	sm: { lineHeight: '1.6', scale: -1 },
-	xl: { lineHeight: '1.5', scale: 2 },
-	xs: { lineHeight: '1.6', scale: -2 },
-};
+const DEFAULT_FLOW_TOKENS: Record<string, FlowTypographyToken> = {};
 
 interface FlowTypePluginOptions {
 	namespace: string;

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -51,7 +51,17 @@ interface FlowTypePluginOptions {
 	tokens: Record<string, FlowTypographyToken>;
 }
 
-type FlowTypePluginUserOptions = Partial<FlowTypePluginOptions>;
+interface FlowTypePluginCssOptions {
+	'replace-default-text-scale'?: boolean;
+	'scale-base-max'?: string;
+	'scale-base-min'?: string;
+	'scale-ratio-max'?: number;
+	'scale-ratio-min'?: number;
+	'scale-viewport-max'?: string;
+	'scale-viewport-min'?: string;
+}
+
+type FlowTypePluginUserOptions = FlowTypePluginCssOptions & Partial<FlowTypePluginOptions>;
 
 const DEFAULT_FLOW_TYPE_OPTIONS: FlowTypePluginOptions = {
 	namespace: 'text',
@@ -63,13 +73,40 @@ const DEFAULT_FLOW_TYPE_OPTIONS: FlowTypePluginOptions = {
 function parseFlowTypePluginOptions(userOptions: FlowTypePluginUserOptions = {}): FlowTypePluginOptions {
 	return {
 		namespace: parseNamespace(userOptions.namespace),
-		replaceDefaultTextScale: shouldReplaceDefaultTextScale(userOptions.replaceDefaultTextScale),
-		scale: userOptions.scale ?? DEFAULT_FLOW_TYPE_OPTIONS.scale,
+		replaceDefaultTextScale: shouldReplaceDefaultTextScale(
+			userOptions.replaceDefaultTextScale ?? userOptions['replace-default-text-scale']
+		),
+		scale: userOptions.scale ?? parseCssScale(userOptions),
 		tokens: {
 			...DEFAULT_FLOW_TYPE_OPTIONS.tokens,
 			...userOptions.tokens,
 		},
 	};
+}
+
+function parseCssScale(userOptions: FlowTypePluginCssOptions): FlowScale {
+	return {
+		base: {
+			max: parseCssString(userOptions['scale-base-max'], DEFAULT_FLOW_SCALE.base.max),
+			min: parseCssString(userOptions['scale-base-min'], DEFAULT_FLOW_SCALE.base.min),
+		},
+		ratio: {
+			max: parseCssNumber(userOptions['scale-ratio-max'], DEFAULT_FLOW_SCALE.ratio.max),
+			min: parseCssNumber(userOptions['scale-ratio-min'], DEFAULT_FLOW_SCALE.ratio.min),
+		},
+		viewport: {
+			max: parseCssString(userOptions['scale-viewport-max'], DEFAULT_FLOW_SCALE.viewport.max),
+			min: parseCssString(userOptions['scale-viewport-min'], DEFAULT_FLOW_SCALE.viewport.min),
+		},
+	};
+}
+
+function parseCssNumber(value: unknown, defaultValue: number): number {
+	return typeof value === 'number' && Number.isFinite(value) ? value : defaultValue;
+}
+
+function parseCssString(value: unknown, defaultValue: string): string {
+	return typeof value === 'string' && value.length > 0 ? value : defaultValue;
 }
 
 function parseNamespace(value: unknown): string {
@@ -80,32 +117,80 @@ function shouldReplaceDefaultTextScale(value: unknown): boolean {
 	return typeof value === 'boolean' ? value : DEFAULT_FLOW_TYPE_OPTIONS.replaceDefaultTextScale;
 }
 
-function createCssThemeTokens(flowTokens: unknown, flowLineHeights: unknown): Record<string, FlowTypographyToken> {
-	if (typeof flowTokens !== 'object' || flowTokens === null || Array.isArray(flowTokens)) {
-		return {};
-	}
-
-	const lineHeights: Record<string, unknown> =
-		typeof flowLineHeights === 'object' && flowLineHeights !== null && !Array.isArray(flowLineHeights)
-			? (flowLineHeights as Record<string, unknown>)
-			: {};
+function createCssThemeTokens(
+	flowTokens: unknown,
+	flowSizes: unknown,
+	flowLineHeights: unknown,
+	flowLetterSpacing: unknown
+): Record<string, FlowTypographyToken> {
+	const modularTokens = flattenThemeValues(flowTokens);
+	const sizes = flattenThemeValues(flowSizes);
+	const lineHeights = flattenThemeValues(flowLineHeights);
+	const letterSpacing = flattenThemeValues(flowLetterSpacing);
 	const tokens: Record<string, FlowTypographyToken> = {};
+	const names = new Set([
+		...Object.keys(modularTokens),
+		...getRangeTokenNames(sizes),
+		...getRangeTokenNames(lineHeights),
+		...Object.keys(letterSpacing),
+	]);
 
-	for (const [name, value] of Object.entries(flowTokens)) {
-		const scale = Number(value);
+	for (const name of names) {
+		const size = createThemeRange(sizes, name);
+		const scale = Number(modularTokens[name]);
 
-		if (!Number.isFinite(scale)) {
+		if (size === undefined && !Number.isFinite(scale)) {
 			continue;
 		}
 
-		const lineHeight = lineHeights[name];
+		const lineHeightRange = createThemeRange(lineHeights, name);
+		const lineHeight = lineHeightRange ?? toCssValue(lineHeights[name]);
+		const tracking = toCssValue(letterSpacing[name]);
 		tokens[name] = {
-			...(typeof lineHeight === 'string' && lineHeight.length > 0 && { lineHeight }),
-			scale,
+			...(lineHeight !== undefined && { lineHeight }),
+			...(tracking !== undefined && { letterSpacing: tracking }),
+			...(size === undefined ? { scale } : { size }),
 		};
 	}
 
 	return tokens;
+}
+
+function createThemeRange(values: Record<string, unknown>, name: string): undefined | { max: string; min: string } {
+	const min = toCssValue(values[`${name}-min`]);
+	const max = toCssValue(values[`${name}-max`]);
+
+	return min === undefined || max === undefined ? undefined : { max, min };
+}
+
+function flattenThemeValues(value: unknown, prefix = ''): Record<string, unknown> {
+	if (typeof value !== 'object' || value === null || Array.isArray(value)) {
+		return {};
+	}
+
+	const values: Record<string, unknown> = {};
+
+	for (const [name, nestedValue] of Object.entries(value)) {
+		const key = prefix.length === 0 ? name : `${prefix}-${name}`;
+
+		if (typeof nestedValue === 'object' && nestedValue !== null && !Array.isArray(nestedValue)) {
+			Object.assign(values, flattenThemeValues(nestedValue, key));
+		} else {
+			values[key] = nestedValue;
+		}
+	}
+
+	return values;
+}
+
+function getRangeTokenNames(values: Record<string, unknown>): string[] {
+	return Object.keys(values)
+		.filter(name => name.endsWith('-min') || name.endsWith('-max'))
+		.map(name => name.slice(0, Math.max(name.lastIndexOf('-min'), name.lastIndexOf('-max'))));
+}
+
+function toCssValue(value: unknown): string | undefined {
+	return typeof value === 'string' || typeof value === 'number' ? value.toString() : undefined;
 }
 
 function createFlowTypePlugin(userOptions: FlowTypePluginUserOptions = {}): PluginCreator {
@@ -115,7 +200,12 @@ function createFlowTypePlugin(userOptions: FlowTypePluginUserOptions = {}): Plug
 		const configuredTokens = {
 			...(options.namespace === 'text' && options.replaceDefaultTextScale && DEFAULT_REPLACEMENT_TOKENS),
 			...options.tokens,
-			...createCssThemeTokens(api.theme('flow-token'), api.theme('flow-line-height')),
+			...createCssThemeTokens(
+				api.theme('flow-token'),
+				api.theme('flow-size'),
+				api.theme('flow-line-height'),
+				api.theme('flow-letter-spacing')
+			),
 		};
 		const tokenEntries = Object.entries(configuredTokens);
 		const tokens = Object.fromEntries(

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -28,6 +28,22 @@ const DEFAULT_FLOW_SCALE: FlowScale = {
 
 const DEFAULT_FLOW_TOKENS: Record<string, FlowTypographyToken> = {};
 
+const DEFAULT_REPLACEMENT_TOKENS: Record<string, FlowTypographyToken> = {
+	'2xl': { lineHeight: '1.5', scale: 3 },
+	'3xl': { lineHeight: '1.5', scale: 4 },
+	'4xl': { lineHeight: '1.5', scale: 5 },
+	'5xl': { lineHeight: '1.4', scale: 6 },
+	'6xl': { lineHeight: '1.4', scale: 7 },
+	'7xl': { lineHeight: '1.4', scale: 8 },
+	'8xl': { lineHeight: '1.4', scale: 9 },
+	'9xl': { lineHeight: '1.3', scale: 10 },
+	base: { lineHeight: '1.6', scale: 0 },
+	lg: { lineHeight: '1.6', scale: 1 },
+	sm: { lineHeight: '1.6', scale: -1 },
+	xl: { lineHeight: '1.5', scale: 2 },
+	xs: { lineHeight: '1.6', scale: -2 },
+};
+
 interface FlowTypePluginOptions {
 	namespace: string;
 	replaceDefaultTextScale: boolean;
@@ -97,6 +113,7 @@ function createFlowTypePlugin(userOptions: FlowTypePluginUserOptions = {}): Plug
 
 	return (api: PluginAPI) => {
 		const configuredTokens = {
+			...(options.namespace === 'text' && options.replaceDefaultTextScale && DEFAULT_REPLACEMENT_TOKENS),
 			...options.tokens,
 			...createCssThemeTokens(api.theme('flow-token'), api.theme('flow-line-height')),
 		};


### PR DESCRIPTION
## Summary

- require explicit tokens for the JavaScript plugin, leaving semantic defaults to the CSS preset
- provide the bundled fluid Tailwind text scale only when `replaceDefaultTextScale` is enabled
- normalize flat CSS scale options for base, ratio, and viewport values
- support CSS modular and explicit tokens, fixed and fluid line-height, and letter-spacing
- document the equivalent CSS and TypeScript configuration surfaces

## Verification

- `bun run lint`
- `bun run typecheck`
- `bun run test`

Closes #125