### PR TITLE
docs: allow manual demo deployments

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,7 @@ on:
     pull_request:
         branches: [ main, develop ]
         types: [ opened, synchronize ]
+    workflow_dispatch:
 
 jobs:
     check:
@@ -92,8 +93,8 @@ jobs:
     deploy-demo:
         name: Deploy demo to GitHub Pages
         runs-on: ubuntu-latest
-        if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' && needs.release.outputs.published == 'true' }}
-        needs: [ release ]
+        if: ${{ always() && ((github.event_name == 'workflow_dispatch' && needs.check.result == 'success') || (github.event_name == 'push' && github.ref == 'refs/heads/main' && needs.release.outputs.published == 'true')) }}
+        needs: [ check, release ]
         concurrency:
             group: github-pages
             cancel-in-progress: false

--- a/README.md
+++ b/README.md
@@ -54,12 +54,6 @@ Build the static demo bundle:
 bun run demo:build
 ```
 
-After the Pages workflow has reached `main`, deploy the demo manually from a local terminal:
-
-```bash
-gh workflow run ci.yml --ref main
-```
-
 ## Usage
 
 ### CSS plugin

--- a/README.md
+++ b/README.md
@@ -54,6 +54,12 @@ Build the static demo bundle:
 bun run demo:build
 ```
 
+After the Pages workflow has reached `main`, deploy the demo manually from a local terminal:
+
+```bash
+gh workflow run ci.yml --ref main
+```
+
 ## Usage
 
 ### CSS plugin


### PR DESCRIPTION
## Summary

- add `workflow_dispatch` to the CI workflow
- allow the Pages job to deploy manually after the check matrix passes
- preserve the automatic Pages deployment condition for published stable releases only
- document the local GitHub CLI command that triggers the remote deployment

## Verification

- `bun run lint`
- `bun run typecheck`
- `bun run test`

Closes #131