### PR TITLE
fix(release): add required permissions to publish job

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,6 +20,11 @@ jobs:
     name: Publish
     needs: [ check, detect-changeset-change ]
     if: github.ref == 'refs/heads/main' || needs.detect-changeset-change.outputs.should_publish_beta == 'true'
+    permissions:
+      contents: 'write'
+      id-token: 'write'
+      issues: 'write'
+      pull-requests: 'write'
     uses: hexadrop/github-workflows/.github/workflows/release.yml@v1
     with:
       snapshot: ${{ github.ref == 'refs/heads/develop' }}


### PR DESCRIPTION
The reusable workflow `hexadrop/github-workflows/.github/workflows/release.yml@v1` requires `id-token: write` (and other permissions) to publish with npm Trusted Publisher.\n\nThis change adds the required permissions to the calling `publish` job so the workflow is valid.